### PR TITLE
Fix map link on initiatives page

### DIFF
--- a/src/pages/initiativen.md
+++ b/src/pages/initiativen.md
@@ -5,7 +5,7 @@ title: 'Ihr gründet Eine Solawi?'
 lead: 'Eine Solawi zu gründen ist sehr aufwendig. Ihr braucht einen Hof und Land, Know-How und Mitstreiter. Ein Eintrag auf ErnteTeilen kann dabei helfen, Euer Projekt voranzubringen indem Menschen aus Eurer Region auf Euch aufmerksam werden.'
 link:
   text: 'Initiative eintragen'
-  href: 'karte#/users/sign-in'
+  href: '/karte#/users/sign-in'
 metaImage: '/img/social_initiatives.jpg'
 ---
 


### PR DESCRIPTION
Main call to action on the initiatives page should use absolute link.

![image](https://github.com/teikei/ernte-teilen.org/assets/449739/18ae5ef6-7b5d-434e-9720-670cfc052be3)
