### PR TITLE
Fix broken link to map page

### DIFF
--- a/src/pages/mitmachen.md
+++ b/src/pages/mitmachen.md
@@ -5,7 +5,7 @@ title: 'Du möchtest bei einer Solawi mitmachen?'
 lead: 'Solawis sind in der Regel um einen Hof herum organisiert und versorgen mehrere Abholstellen mit Lebensmitteln. Um teilzunehmen musst Du Mitglied einer Solawi werden, die eine Abholstelle in Deiner Nähe hat. Unsere interaktive Karte kann Dir dabei helfen, eine Solawi in Deiner Region zu finden.'
 link:
   text: 'Direkt zur Karte'
-  href: 'karte'
+  href: '/karte'
 metaImage: '/img/social_consumers.jpg'
 ---
 


### PR DESCRIPTION
Main call to action on the "mitmachen" page should use absolute link.

