### PR TITLE
Update legacy styles for teikei user menu

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,3 @@
-const browserslist = require('browserslist')
-const autoprefixer = require('autoprefixer')
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
 })
@@ -8,9 +6,6 @@ module.exports = {
   plugins: [
     {
       resolve: 'gatsby-plugin-sass',
-      options: {
-        postCssPlugins: [autoprefixer({ browsers: browserslist() })],
-      },
     },
     {
       resolve: 'gatsby-source-filesystem',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "autoprefixer": "^9.0.1",
-        "browserslist": "^4.0.1",
         "carbon-components": "^9.26.0",
         "carbon-components-react": "^6.38.1",
         "carbon-icons": "^7.0.7",
@@ -5524,51 +5522,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "9.8.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
-      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
-      "dependencies": {
-        "browserslist": "^4.12.0",
-        "caniuse-lite": "^1.0.30001109",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "picocolors": "^0.2.1",
-        "postcss": "^7.0.32",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-      }
-    },
-    "node_modules/autoprefixer/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/autoprefixer/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -6328,9 +6281,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001559",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
-      "integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6344,7 +6297,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -14751,11 +14705,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
-    },
-    "node_modules/num2fraction": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg=="
     },
     "node_modules/number-is-nan": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "npm": "10.x"
   },
   "dependencies": {
-    "autoprefixer": "^9.0.1",
-    "browserslist": "^4.0.1",
     "carbon-components": "^9.26.0",
     "carbon-components-react": "^6.38.1",
     "carbon-icons": "^7.0.7",

--- a/src/styles/_teikei-legacy.scss
+++ b/src/styles/_teikei-legacy.scss
@@ -9,29 +9,18 @@
   display: none;
 }
 
-@media screen and (min-width: 760px) {
-  #teikei-app .user-nav {
-    z-index: 10; // move z-index down so that it does not overlap the website nav
-  }
-
-  #teikei-app .account-nav {
-    top: 180px;
-    right: 20px;
-  }
-
-  #teikei-app .account-nav-login {
-    top: 120px;
-    right: 20px;
-  }
-
-  #teikei-app .details {
-    padding-top: 210px;
-  }
+#teikei-app .user-nav {
+  top: 85px;
 }
 
-@media screen and (min-width: 960px) {
+@media screen and (min-width: 760px) {
+  #teikei-app .user-nav {
+    top: 0;
+    padding-right: 40px;
+  }
+
   #teikei-app .account-nav {
     top: 120px;
-    right: 320px;
+    right: 140px;
   }
 }

--- a/src/styles/_teikei-legacy.scss
+++ b/src/styles/_teikei-legacy.scss
@@ -9,8 +9,16 @@
   display: none;
 }
 
-#teikei-app .user-nav {
-  top: 85px;
+@media screen and (max-width: 759px) {
+  #teikei-app .user-nav {
+    top: 85px;
+  }
+
+  #teikei-app .account-nav-login {
+    padding: 3px 6px;
+    color: white !important;
+    font-weight: bold;
+  }
 }
 
 @media screen and (min-width: 760px) {
@@ -22,5 +30,10 @@
   #teikei-app .account-nav {
     top: 120px;
     right: 140px;
+  }
+
+  #teikei-app .account-nav-login {
+    top: 120px;
+    right: 0;
   }
 }


### PR DESCRIPTION
- Fix legacy styles to work with the current teikei user menu
- Bonus: Remove `autoprefixer` & `browserlist` (no longer needed)