### PR TITLE
fix(deploy): unpin heroku nodejs buildpack so Node 24 builds on Dokku

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/heroku/heroku-buildpack-nodejs#v175
+https://github.com/heroku/heroku-buildpack-nodejs
 https://github.com/heroku/heroku-buildpack-static.git


### PR DESCRIPTION
## Problem

The Dokku deploy fails at dependency install:

```
-----> Installing dependencies
       Installing node modules (package.json + package-lock)
       npm ERR! cb.apply is not a function
```

`cb.apply is not a function` is the signature of an **ancient npm (v6) running on a modern Node**.

## Root cause

`.buildpacks` pinned the Node buildpack to **`#v175`** (2021), which predates Node 24 (now in `engines.node`) and can't provision a compatible npm for it. It worked under Gatsby only because that used Node 20 with an explicit `npm: 10.x` pin — both of which were removed in the cutover.

## Fix

Unpin the Node buildpack so it tracks the maintained latest (v351+), which supports Node 24 and ships a compatible npm. This also matches `app.json`'s already-unpinned `heroku/nodejs`, and prevents the same stale-pin problem from recurring.

Build-critical deps (`sass`, `carbon-components`) are already in `dependencies`, so they survive the buildpack's prune step.

Minimal one-line change; merge to `preview` to re-trigger the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)