### PR TITLE
Add grouped Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+multi-ecosystem-groups:
+  monthly-dependencies:
+    schedule:
+      interval: monthly
+      time: '07:00'
+      timezone: Europe/Berlin
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: preview
+    patterns:
+      - '*'
+    multi-ecosystem-group: monthly-dependencies
+    open-pull-requests-limit: 1
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: preview
+    patterns:
+      - '*'
+    multi-ecosystem-group: monthly-dependencies
+    open-pull-requests-limit: 1
+    groups:
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
Adds Dependabot config for monthly grouped npm and GitHub Actions version updates targeting preview. Groups security updates per ecosystem where GitHub supports it and caps routine version-update PR noise. Validation: npm test.